### PR TITLE
Make builds reproducible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/bin/epic_miner.rs"
 [dependencies]
 backtrace = "0.3"
 bufstream = "~0.1"
-native-tls = "0.2"
+native-tls = "0.2.11"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
@@ -35,7 +35,6 @@ term = "0.4"
 time = "0.1"
 rand = "^0.3.16"
 clap = { version = "2.31", features = ["yaml"] }
-openssl = { version = "0.10", features = ["vendored"] }
 
 epic_miner_core = { path = "./core", version = "0.1.0" }
 epic_miner_util = { path = "./util", version = "1.0.2" }
@@ -46,13 +45,11 @@ ocl_cuckatoo = { path = "./ocl_cuckatoo", version = "1.0.2", optional = true}
 randomx = { path = "./randomx-rust", version = "0.1.0" }
 randomx_miner = { path = "./randomx-miner", version = "0.1.0" }
 
-[target.'cfg(windows)'.dependencies]
-cursive = { version = "0.14", default-features = false, features = ["pancurses-backend"] }
+cursive = { version = "~0.16", default-features = false, features = ["pancurses-backend"] }
+
 [target.'cfg(windows)'.dependencies.pancurses]
-version = "0.16.0"
+version = "~0.16"
 features = ["win32"]
-[target.'cfg(unix)'.dependencies]
-cursive = "0.12"
 
 [[test]]
 name = "cucumber"

--- a/src/bin/epic_miner.rs
+++ b/src/bin/epic_miner.rs
@@ -78,10 +78,9 @@ pub fn info_strings() -> (String, String, String) {
 		)
 		.to_string(),
 		format!(
-			"Built with profile \"{}\", features \"{}\" on {}.",
+			"Built with profile \"{}\", features \"{}\".",
 			built_info::PROFILE,
-			built_info::FEATURES_STR,
-			built_info::BUILT_TIME_UTC
+			built_info::FEATURES_STR
 		)
 		.to_string(),
 		format!("Dependencies:\n {}", built_info::DEPENDENCIES_STR).to_string(),

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -15,5 +15,5 @@ rand = "0.3"
 serde = "1"
 serde_derive = "1"
 slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_trace"] }
-slog-term = "2.1"
-slog-async = "2.1"
+slog-term = "~2.5"
+slog-async = "~2.5"


### PR DESCRIPTION
# Description

Make the builds have a deterministic behavior.

- Remove the duplicated library openssl
- Change the `build.rs` to not register the build timestamp into the binaries

Also fix the cargo update by putting bad libraries:

- Froze the following libraries:
  - Cursive: Freezed to ~0.16, also changed dependencies to use pancurses on both linux and windows
- slog-term and slog-async: Both froze to "~2.5"

This will allow us to have a better version control

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Ubuntu 20.04.5 LTS
- Windows 10

# Relevant notes

No notes