### PR TITLE
Pull in latest v0.1.1 randomx-rust submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "cuckoo-miner/src/cuckoo_sys/plugins/cuckoo"]
 	path = cuckoo-miner/src/cuckoo_sys/plugins/cuckoo
 	url = https://github.com/tromp/cuckoo.git
-[submodule "randomx-rust"]
-	path = randomx-rust
-	url = ../randomx-rust.git
 [submodule "progpow-rust"]
 	path = progpow-rust
-	url = ../progpow-rust.git
+	url = https://github.com/EpicCash/progpow-rust.git
+[submodule "randomx-rust"]
+	path = randomx-rust
+	url = https://github.com/EpicCash/randomx-rust.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "randomx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bigint",
  "bindgen",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "randomx_miner"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bigint",
  "epic_miner_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ epic_miner_plugin = { path = "./plugin", version = "1.0.2" }
 epic_miner_config = { path = "./config", version = "1.0.2" }
 #use this alternative inclusion below to build cuda plugins
 ocl_cuckatoo = { path = "./ocl_cuckatoo", version = "1.0.2", optional = true}
-randomx = { path = "./randomx-rust", version = "0.1.0" }
-randomx_miner = { path = "./randomx-miner", version = "0.1.0" }
+randomx = { path = "./randomx-rust", version = "0.1.1" }
+randomx_miner = { path = "./randomx-miner", version = "0.1.1" }
 
 [target.'cfg(windows)'.dependencies]
 cursive = { version = "0.14", default-features = false, features = ["pancurses-backend"] }

--- a/randomx-miner/Cargo.toml
+++ b/randomx-miner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "randomx_miner"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 lazy_static = "1.3.0"
@@ -10,4 +10,4 @@ slog = { version = "~2.1", features = ["max_level_trace", "release_max_level_tra
 
 epic_miner_core = { path = "../core", version = "0.1.0" }
 epic_miner_util = { path = "../util", version = "1.0.2" }
-randomx = { path = "../randomx-rust", version = "0.1.0" }
+randomx = { path = "../randomx-rust", version = "0.1.1" }


### PR DESCRIPTION
- Commits since v0.1.0 now compile `librandomx` as a static library, removing linkage issues against `librandomx.so`
- Dynamic library was being built, but linker could not find it